### PR TITLE
first pass at %add-column

### DIFF
--- a/lib/nectar.hoon
+++ b/lib/nectar.hoon
@@ -39,6 +39,7 @@
       %rename-table  `(rename-table app^old.query app^new.query)
       %drop-table    `(drop-table app^name.query)
       %update-rows   `(update-rows app^table.query rows.query)
+      %add-column    `(add-column app^table.query col-name.query column-type.query)
     ==
   ::
   ++  add-table
@@ -93,6 +94,13 @@
     =^  rows  table
       (~(update tab table) primary-key.table where.query cols.query)
     [rows (~(put by database) app^table.query table)]
+  ::
+  ++  add-column
+    |=  [name=table-name col-name=term =column-type]
+    ^+  database
+    =/  =table  (~(got by database) name) 
+    =.  table  (~(add-column tab table) col-name column-type)
+    (~(put by database) name table)
   ::
   ::  run a NON-MUTATING query and get a list of rows as a result
   ::
@@ -219,10 +227,11 @@
     ::  can only have 1 primary key, must be the indicated one
     ::
     ?>  .=  1
-        %-  lent
-        %+  skim  ~(tap by indices.table)
-        |=  [(list term) key-type]
-        primary
+      %-  lent
+      %+  skim  ~(tap by indices.table)
+      |=  [(list term) key-type]
+      primary
+    ~|  "Primary key must also be a unique index."
     ?>  &(primary unique):(~(got by indices.table) primary-key.table)
     ::
     ::  columns must be contiguous from 0
@@ -761,6 +770,20 @@
     %+  weld
       (get-rows at-key)
     q.with
+  ::
+  ::  add-column: adds new column into table records
+  ::
+  ++  add-column
+    |=  [col-name=term =column-type]
+    ::  add new column to schema
+    =.  schema.table  (~(put by schema.table) col-name column-type)
+    ::  add new empty column to records
+    =/  new-rows=(list row)
+      %+  turn
+        `(list row)`(~(get-rows tab table) ~)
+      |=  =row
+      `^row`(welp row ~[0])
+    (insert new-rows update=&)
   --
 ::
 ++  apply-condition

--- a/lib/nectar.hoon
+++ b/lib/nectar.hoon
@@ -39,7 +39,7 @@
       %rename-table  `(rename-table app^old.query app^new.query)
       %drop-table    `(drop-table app^name.query)
       %update-rows   `(update-rows app^table.query rows.query)
-      %add-column    `(add-column app^table.query col-name.query column-type.query)
+      %add-column    `(add-column app^table.query col-name.query column-type.query fill.query)
     ==
   ::
   ++  add-table
@@ -96,10 +96,10 @@
     [rows (~(put by database) app^table.query table)]
   ::
   ++  add-column
-    |=  [name=table-name col-name=term =column-type]
+    |=  [name=table-name col-name=term =column-type fill=value]
     ^+  database
     =/  =table  (~(got by database) name) 
-    =.  table  (~(add-column tab table) col-name column-type)
+    =.  table  (~(add-column tab table) col-name column-type fill)
     (~(put by database) name table)
   ::
   ::  run a NON-MUTATING query and get a list of rows as a result
@@ -231,7 +231,7 @@
       %+  skim  ~(tap by indices.table)
       |=  [(list term) key-type]
       primary
-    ~|  "Primary key must also be a unique index."
+    ~|  "%nectar: primary key must also be a unique index"
     ?>  &(primary unique):(~(got by indices.table) primary-key.table)
     ::
     ::  columns must be contiguous from 0
@@ -774,15 +774,28 @@
   ::  add-column: adds new column into table records
   ::
   ++  add-column
-    |=  [col-name=term =column-type]
-    ::  add new column to schema
-    =.  schema.table  (~(put by schema.table) col-name column-type)
+    |=  [col-name=term =column-type fill=value]
+    =.  schema.table
+      ::  always add the new column
+      =;  new=schema
+        (~(put by new) col-name column-type)
+      ::  if spot taken, shift existing spots that come after to the right
+      =+  %+  turn  
+            ~(val by schema.table) 
+          |=(a=^column-type spot.a)
+      ?~  %+(find ~[spot.column-type] -)
+        schema.table
+      %-  ~(urn by schema.table)
+      |=  [term b=^column-type]  
+      ?.  (gte spot.b spot.column-type)
+        b 
+      b(spot +(spot.b))
     ::  add new empty column to records
     =/  new-rows=(list row)
       %+  turn
         `(list row)`(~(get-rows tab table) ~)
       |=  =row
-      `^row`(welp row ~[0])
+      `^row`(into row spot.column-type fill)
     (insert new-rows update=&)
   --
 ::

--- a/sur/nectar.hoon
+++ b/sur/nectar.hoon
@@ -3,6 +3,7 @@
 ::            database
 ::
 |%
+::  +database map of table
 +$  database  (map table-name table)
 ::  need name of app poking to be in bowl! for now, this:
 +$  query-poke      [app=@tas =query]
@@ -111,7 +112,7 @@
       [%add-table name=@ actual=table]
       [%rename-table old=@ new=@]
       [%drop-table name=@]
-      [%add-column table=@ col-name=@ =column-type]
+      [%add-column table=@ col-name=@ =column-type fill=value]
       ::  %drop-column
       ::  %edit-column
       ::  ??

--- a/sur/nectar.hoon
+++ b/sur/nectar.hoon
@@ -111,7 +111,7 @@
       [%add-table name=@ actual=table]
       [%rename-table old=@ new=@]
       [%drop-table name=@]
-      ::  %add-column
+      [%add-column table=@ col-name=@ =column-type]
       ::  %drop-column
       ::  %edit-column
       ::  ??


### PR DESCRIPTION
My first attempt at adding the `%add-column` query. There are some things that I am unsure of so I am posting what I have so far to make sure I'm on the right track.

The %add-column query is  `['%add-column table=@ col-name=@ =column-type]`. 

Inside of `db`, I added a gate for add-column which then calls the corresponding `+add-column` arm inside of `tab`.

`~(add-column tab table)` does three things
1. Adds the `column-type` to the schema (but does not validate that they are valid)
2. Inserts nulls at the end of each row. The implicit assumption is that the new column is going to be in the last `spot`. 
3. Calls `~(insert tab table)` to add the zero-concated rows to the table.

How I've been using it:

1. Import this core under the name of `nec-box`:

```hoon
|%
++  variable-length-db
  |=  n-rows=@ud
  |^  
  ^-  database 
  =/  deebee=database  empty-database
  %+  ~(insert-rows db deebee) 
    %myapp^%boards  (create-rows n-rows)
  
  ++  create-rows
    |=  n=@ud
    ^-  (list row)
    =/  c  1
    =/  rows=(list row)  ~[`row`~[id=0 name='0']]
    |-
    ?:  =(c n)
      rows
    %=  $
      c   +(c)
      rows  (weld rows ~[`row`~[id=c name=(crip "{<c>}")]])
    ==
  ++  empty-database
    %+  ~(add-table db *database)
      %myapp^%boards
    ^-  table
    :^    (make-schema ~[[%id [0 %.n %ud]] [%name [1 %.n %t]]])
        primary-key=~[%id]
      (make-indices ~[[~[%id] primary=& autoincrement=~ unique=& clustered=|]])
    ~
  --
--
```

2. Run the following dojo commands
```
> =db (variable-length-db:nec-box 10)
> (run-mutation:nec-box db [%add-column %boards %nu [2 %.n %ud]])