### PR TITLE
restructure linedb.hoon to use $wain

### DIFF
--- a/lib/docket.hoon
+++ b/lib/docket.hoon
@@ -1,1 +1,1 @@
-../../garden-dev/lib/docket.hoon
+../../landscape/lib/docket.hoon

--- a/lib/linedb.hoon
+++ b/lib/linedb.hoon
@@ -5,57 +5,40 @@
   |%
   ::
   ++  add-commit
-    |=  [author=ship diffs=(list diff)]
+    |=  [author=ship new-snap=snapshot]
     ^+  branch
-    =/  =commit
+    =*  commit
       :+  author
-        %+  build-snapshot
-          ?:  =(0 head)  ~
-          snapshot:(got:snap-on snaps head)
-        diffs
-      diffs
+        new-snap
+      ?:  =(0 head)  (build-diff ~ new-snap)
+      (build-diff snapshot:(got:snap-on snaps head) new-snap)
     %=  +>.$
       head   +(head)
       snaps  (put:snap-on snaps +(head) commit)
     ==
   ::
-  ::  do stuff like revert by setting head backwards
-  ::
   ++  set-head
     |=  new-head=@ud
     ^+  branch
-    ::  enforce that head can't go beyond highest index
     ?>  (has:snap-on snaps new-head)
     +>.$(head new-head)
   ::
-  ::  construct new snapshot from old snapshot + list of diffs
-  ::
-  ++  build-snapshot
-    |=  [old=snapshot diffs=(list diff)]
-    ^-  snapshot
-    ::  iteratively apply diffs to associated docs
-    ::  if a diff is for a doc-name we don't have, make that doc
-    ::  (?) if a diff removes all lines from a doc, delete (?)
-    |-
-    ?~  diffs  old
-    =*  diff  i.diffs
-    %=    $
-        diffs  t.diffs
-        old
-      %+  ~(put by old)
-        doc-name.diff
-      ?~  d=(~(get by old) doc-name.diff)
-        `doc`(put:doc-on *doc [line-num line]:diff)
-      `doc`(put:doc-on u.d [line-num line]:diff)
-    ==
-  ::
-  ::  given a branch and doc, gets that doc
+  ++  build-diff
+    |=  [old=snapshot new=snapshot]
+    ^-  (map path diff)
+    %-  ~(urn by (~(uni by old) new))
+    |=  [=path *]
+    ^-  diff
+    =/  a=file
+      ?~(got=(~(get by old) path) *file u.got)
+    =/  b=file
+      ?~(got=(~(get by new) path) *file u.got)
+    (lusk:differ a b (loss:differ a b))
   ::
   ++  read-doc
-    |=  [=doc-name]
-    ^-  cord
-    =+  snapshot:(got:snap-on snaps head)
+    |=  =file-name
+    ^-  cord 
     %-  of-wain:format
-    (turn (tap:doc-on (~(got by -) doc-name)) tail)
+    (~(got by snapshot:(got:snap-on snaps head)) file-name)
   --
 --

--- a/mar/md.hoon
+++ b/mar/md.hoon
@@ -1,0 +1,1 @@
+../../arvo/mar/md.hoon

--- a/sur/docket.hoon
+++ b/sur/docket.hoon
@@ -1,1 +1,1 @@
-../../garden-dev/sur/docket.hoon
+../../landscape/sur/docket.hoon

--- a/sur/linedb.hoon
+++ b/sur/linedb.hoon
@@ -1,47 +1,23 @@
 |%
 ::  snapshots are full document sets with all lines
-::  structural sharing makes this efficient
+::  structural sharing makes this efficient?
 ::
-::  a branch is an ordered history of snapshots
-::
+::  a branch is an ordered history of snapshots.
 ::  make a new branch by selecting an existing one to go off
-::  can make a branch with no parent that starts empty?
 ::
-::  to add a commit to a branch, simply
-::  - apply a (list diff) to the current snapshot
-::  - attach the commit plus the new snapshot at +(index)
-::  - update head of the branch
+::  to add a commit to a branch, simply call +add-commit:branch
+::  with your files
 ::
-::  to see contents of repo in branch at commit:
-::  - get snapshot at index of commit in branch
-::
-::  to see changes at commit:
-::  - look at diff paired with snapshot at index
-::
-::  to build a commit, apply each diff in list
-::  to snapshot at head index of branch.
-::
-+$  line      cord
-+$  line-num  @ud
-+$  index     @ud
-+$  doc       ((mop line-num line) lth)
-+$  doc-name  path
-::
-+$  diff      [=doc-name =line-num =line]
-::
-+$  snapshot  (map doc-name doc)
-::
++$  index      @ud
++$  file       wain
++$  file-name  path
++$  diff       (urge:clay cord)
++$  snapshot   (map file-name file)
 +$  commit
   $:  author=ship
       =snapshot
-      diffs=(list diff)
+      diffs=(map file-name diff)
   ==
 ::
-+$  branch
-  $:  snaps=((mop index commit) lth)
-      head=index
-  ==
-::
-++  doc-on    ((on line-num line) lth)
-++  snap-on   ((on index commit) lth)
+++  snap-on  ((on index commit) lth)
 --


### PR DESCRIPTION
one thing to note is you don't build a file by repeatedly applying diffs, instead the diffs are constructed from the two different file systems. I don't think we lose anything this way? Structural sharing from `$wain`s mean the memory usage should be the same